### PR TITLE
Remove 'FINAL' keyword because we don't need it

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -271,7 +271,6 @@ KEYWORDS = {
     'FALSE': tokens.Keyword,
     'FETCH': tokens.Keyword,
     'FILE': tokens.Keyword,
-    'FINAL': tokens.Keyword,
     'FIRST': tokens.Keyword,
     'FORCE': tokens.Keyword,
     'FOREACH': tokens.Keyword,

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -412,6 +412,9 @@ def test_format_invalid_where_clause():
     formatted = sqlparse.format('where, foo', reindent=True)
     assert formatted == 'where, foo'
 
+def test_cte_named_final():
+    p = sqlparse.parse('with final as (select 1) select final')[0]
+    assert p.get_type() == 'SELECT'
 
 def test_splitting_at_and_backticks_issue588():
     splitted = sqlparse.split(


### PR DESCRIPTION
Users reported issues when using `final` as the name of a CTE, which was caused because sqlparse treats it as a reserved keyword. It appears to me that this is only a keyword in DB2 SQL, which I don't think we care much about, so I've simply removed it from the keyword list.