### PR TITLE
track token position and lengths

### DIFF
--- a/sqlparse/engine/statement_splitter.py
+++ b/sqlparse/engine/statement_splitter.py
@@ -81,7 +81,7 @@ class StatementSplitter:
         EOS_TTYPE = T.Whitespace, T.Comment.Single
 
         # Run over all stream tokens
-        for ttype, value in stream:
+        for ttype, value, position in stream:
             # Yield token if we finished a statement and there's no whitespaces
             # It will count newline token as a non whitespace. In this context
             # whitespace ignores newlines.
@@ -96,7 +96,7 @@ class StatementSplitter:
             self.level += self._change_splitlevel(ttype, value)
 
             # Append the token to the current statement
-            self.tokens.append(sql.Token(ttype, value))
+            self.tokens.append(sql.Token(ttype, value, position))
 
             # Check if we get the end of a statement
             if self.level <= 0 and ttype is T.Punctuation and value == ';':

--- a/sqlparse/filters/tokens.py
+++ b/sqlparse/filters/tokens.py
@@ -16,10 +16,10 @@ class _CaseFilter:
         self.convert = getattr(str, case)
 
     def process(self, stream):
-        for ttype, value in stream:
+        for ttype, value, position in stream:
             if ttype in self.ttype:
                 value = self.convert(value)
-            yield ttype, value
+            yield ttype, value, position
 
 
 class KeywordCaseFilter(_CaseFilter):
@@ -30,10 +30,10 @@ class IdentifierCaseFilter(_CaseFilter):
     ttype = T.Name, T.String.Symbol
 
     def process(self, stream):
-        for ttype, value in stream:
+        for ttype, value, position in stream:
             if ttype in self.ttype and value.strip()[0] != '"':
                 value = self.convert(value)
-            yield ttype, value
+            yield ttype, value, position
 
 
 class TruncateStringFilter:
@@ -42,9 +42,9 @@ class TruncateStringFilter:
         self.char = char
 
     def process(self, stream):
-        for ttype, value in stream:
+        for ttype, value, position in stream:
             if ttype != T.Literal.String.Single:
-                yield ttype, value
+                yield ttype, value, position
                 continue
 
             if value[:2] == "''":
@@ -56,4 +56,4 @@ class TruncateStringFilter:
 
             if len(inner) > self.width:
                 value = ''.join((quote, inner[:self.width], self.char, quote))
-            yield ttype, value
+            yield ttype, value, position

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -136,20 +136,20 @@ class Lexer:
                 if not m:
                     continue
                 elif isinstance(action, tokens._TokenType):
-                    yield action, m.group()
+                    yield action, m.group(), pos
                 elif action is keywords.PROCESS_AS_KEYWORD:
-                    yield self.is_keyword(m.group())
+                    yield (*self.is_keyword(m.group()), pos)
 
                 consume(iterable, m.end() - pos - 1)
                 break
             else:
-                yield tokens.Error, char
+                yield tokens.Error, char, pos
 
 
 def tokenize(sql, encoding=None):
     """Tokenize sql.
 
-    Tokenize *sql* using the :class:`Lexer` and return a 2-tuple stream
-    of ``(token type, value)`` items.
+    Tokenize *sql* using the :class:`Lexer` and return a 3-tuple stream
+    of ``(token type, value, position)`` items.
     """
     return Lexer.get_default_instance().get_tokens(sql, encoding)

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -47,7 +47,7 @@ class Token:
     __slots__ = ('value', 'ttype', 'parent', 'normalized', 'is_keyword',
                  'is_group', 'is_whitespace', 'position', 'length')
 
-    def __init__(self, ttype, value, position = None):
+    def __init__(self, ttype, value, position=None):
         value = str(value)
         self.value = value
         self.ttype = ttype

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -45,9 +45,9 @@ class Token:
     """
 
     __slots__ = ('value', 'ttype', 'parent', 'normalized', 'is_keyword',
-                 'is_group', 'is_whitespace')
+                 'is_group', 'is_whitespace', 'position', 'length')
 
-    def __init__(self, ttype, value):
+    def __init__(self, ttype, value, position = None):
         value = str(value)
         self.value = value
         self.ttype = ttype
@@ -56,6 +56,8 @@ class Token:
         self.is_keyword = ttype in T.Keyword
         self.is_whitespace = self.ttype in T.Whitespace
         self.normalized = value.upper() if self.is_keyword else value
+        self.position = position
+        self.length = len(value)
 
     def __str__(self):
         return self.value
@@ -160,6 +162,15 @@ class TokenList(Token):
         [setattr(token, 'parent', self) for token in self.tokens]
         super().__init__(None, str(self))
         self.is_group = True
+        if (
+            len(self.tokens) > 0
+            and self.tokens[0].position is not None
+            and self.tokens[-1].position is not None
+        ):
+            self.position = self.tokens[0].position
+            self.length = (
+                self.tokens[-1].position - self.tokens[0].position
+            ) + self.tokens[-1].length
 
     def __str__(self):
         return ''.join(token.value for token in self.flatten())

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -14,16 +14,16 @@ def test_tokenize_simple():
     assert isinstance(stream, types.GeneratorType)
     tokens = list(stream)
     assert len(tokens) == 8
-    assert len(tokens[0]) == 2
-    assert tokens[0] == (T.Keyword.DML, 'select')
-    assert tokens[-1] == (T.Punctuation, ';')
+    assert len(tokens[0]) == 3
+    assert tokens[0] == (T.Keyword.DML, 'select', 0)
+    assert tokens[-1] == (T.Punctuation, ';', 17)
 
 
 def test_tokenize_backticks():
     s = '`foo`.`bar`'
     tokens = list(lexer.tokenize(s))
     assert len(tokens) == 3
-    assert tokens[0] == (T.Name, '`foo`')
+    assert tokens[0] == (T.Name, '`foo`', 0)
 
 
 @pytest.mark.parametrize('s', ['foo\nbar\n', 'foo\rbar\r',


### PR DESCRIPTION
This PR updates sqlparse to keep track of token positions and lengths. We actually already have some logic added to our fork of `sql-metadata` to try to do something similar, but I think it will be more robust to handle this at the sqlparse level because its lexer is seeing the exact original position of each token in the source text whereas sql-metadata has to try to reconstruct positions from sqlparse's output