### PR TITLE
add keywords for duckdb pivot statements, from-first syntax

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -43,6 +43,7 @@ SQL_REGEX = [
     # AS and IN are special, it may be followed by a parenthesis, but
     # are never functions, see issue183 and issue507
     (r'(CASE|IN|VALUES|USING|FROM|AS)\b', tokens.Keyword),
+    (r'(PIVOT|PIVOT_WIDER|UNPIVOT)\b', tokens.Keyword),
 
     (r'(@|##|#)[A-ZÀ-Ü]\w+', tokens.Name),
 

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -958,3 +958,14 @@ KEYWORDS_HQL = {
 KEYWORDS_MSACCESS = {
     'DISTINCTROW': tokens.Keyword,
 }
+
+KEYWORDS_DUCKDB = {
+    # duckdb supports FROM-first syntax which may even omit the SELECT, so
+    # e.g. `from dataframe` is a full, valid query
+    'FROM': tokens.Keyword.DML,
+
+    # https://duckdb.org/docs/sql/statements/pivot
+    'PIVOT': tokens.Keyword.DML,
+    'PIVOT_WIDER': tokens.Keyword.DML,
+    'UNPIVOT': tokens.Keyword.DML,
+}

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -62,6 +62,7 @@ class Lexer:
         self.add_keywords(keywords.KEYWORDS_PLPGSQL)
         self.add_keywords(keywords.KEYWORDS_HQL)
         self.add_keywords(keywords.KEYWORDS_MSACCESS)
+        self.add_keywords(keywords.KEYWORDS_DUCKDB)
         self.add_keywords(keywords.KEYWORDS)
 
     def clear(self):

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -57,12 +57,12 @@ class Lexer:
         Useful if you need to revert custom syntax settings."""
         self.clear()
         self.set_SQL_REGEX(keywords.SQL_REGEX)
+        self.add_keywords(keywords.KEYWORDS_DUCKDB)
         self.add_keywords(keywords.KEYWORDS_COMMON)
         self.add_keywords(keywords.KEYWORDS_ORACLE)
         self.add_keywords(keywords.KEYWORDS_PLPGSQL)
         self.add_keywords(keywords.KEYWORDS_HQL)
         self.add_keywords(keywords.KEYWORDS_MSACCESS)
-        self.add_keywords(keywords.KEYWORDS_DUCKDB)
         self.add_keywords(keywords.KEYWORDS)
 
     def clear(self):


### PR DESCRIPTION
[SUP-1069](https://linear.app/hex/issue/SUP-1069/graph-execution-model-bug-with-sql-cells) this PR updates sqlparse's keyword list and SQL regex to start to recognize a couple of exotic syntax forms that duckdb recognizes and which are causing dataframe dependencies not to be captured in our current parsing

- DuckDB supports a FROM-first query syntax where you may even omit the entire `select` so that e.g. `from dataframe` is a full, valid query
- DuckDB supports `PIVOT`/`UNPIVOT` _statements_, as distinct from the non-standardized but fairly widespread pivot operator (for example [Snowflake](https://docs.snowflake.com/en/sql-reference/constructs/pivot), [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#pivot_operator))