### PR TITLE
fix handling of duckdb syntax with CTEs

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -410,8 +410,10 @@ class TokenList(Token):
             elif isinstance(token, (Identifier, Function)):
                 return token.get_real_name() if real_name else token.get_name()
 
+
 # duckdb supports FROM-first syntax, PIVOT statements
 SELECT_LIKE = {'FROM', 'PIVOT', 'PIVOT_WIDER', 'UNPIVOT'}
+
 
 class Statement(TokenList):
     """Represents a SQL statement."""

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -410,6 +410,8 @@ class TokenList(Token):
             elif isinstance(token, (Identifier, Function)):
                 return token.get_real_name() if real_name else token.get_name()
 
+# duckdb supports FROM-first syntax, PIVOT statements
+SELECT_LIKE = {'FROM', 'PIVOT', 'PIVOT_WIDER', 'UNPIVOT'}
 
 class Statement(TokenList):
     """Represents a SQL statement."""
@@ -433,8 +435,7 @@ class Statement(TokenList):
         elif token.ttype in (T.Keyword.DML, T.Keyword.DDL):
             return token.normalized
 
-        # duckdb supports FROM-first syntax, PIVOT statements
-        elif token.normalized in {'FROM', 'PIVOT', 'PIVOT_WIDER', 'UNPIVOT'}:
+        elif token.normalized in SELECT_LIKE:
             return 'SELECT'
 
         elif token.ttype == T.Keyword.CTE:
@@ -450,6 +451,8 @@ class Statement(TokenList):
                     if token is not None \
                             and token.ttype == T.Keyword.DML:
                         return token.normalized
+                    elif token.normalized in SELECT_LIKE:
+                        return 'SELECT'
 
         # Hmm, probably invalid syntax, so return unknown.
         return 'UNKNOWN'

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -15,3 +15,13 @@ USING sum(value_count)
 GROUP BY value_id
 """)[0]
     assert statement.get_type() == "SELECT"
+
+
+def test_pivot_with_cte():
+    statement = sqlparse.parse("""
+with my_cte as (
+    select * from df
+)
+PIVOT my_cte ON date USING SUM(number)
+""")[0]
+    assert statement.get_type() == "SELECT"


### PR DESCRIPTION
I did a previous pass (or two) at handling this syntax but it wasn't properly handling the case where the syntax was used with CTEs before it