### PR TITLE
ignore unecessary wrapping parens when determining statement type

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -429,6 +429,10 @@ class Statement(TokenList):
         are ignored.
         """
         token = self.token_first(skip_cm=True)
+
+        while isinstance(token, Parenthesis):
+            token = token.token_next(0, skip_cm=True)[1]
+
         if token is None:
             # An "empty" statement that either has not tokens at all
             # or only whitespace tokens.

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -166,3 +166,9 @@ def test_split_mysql_handler_for(load_file):
     # see issue581
     stmts = sqlparse.split(load_file('mysql_handler.sql'))
     assert len(stmts) == 2
+
+
+def test_unecessary_parens():
+    (stmt,) = sqlparse.parse("(select * from foo)")
+    stmt._pprint_tree()
+    assert stmt.get_type() == "SELECT"

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -170,5 +170,4 @@ def test_split_mysql_handler_for(load_file):
 
 def test_unecessary_parens():
     (stmt,) = sqlparse.parse("(select * from foo)")
-    stmt._pprint_tree()
     assert stmt.get_type() == "SELECT"


### PR DESCRIPTION
[NOVA-1788](https://linear.app/hex/issue/NOVA-1788/dataframe-references-not-seen-when-queries-are-wrapped-in-parentheses) many dialects allow statements to be wrapped in unnecessary parens. sqlparse was assigning these the statement type UNKNOWN which we were ignoring downstream.