### PR TITLE
define (and export) all valid join types

### DIFF
--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -14,6 +14,7 @@ from sqlparse import engine
 from sqlparse import tokens
 from sqlparse import filters
 from sqlparse import formatter
+from sqlparse import keywords
 
 
 __version__ = '0.5.0.dev0'

--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -14,7 +14,7 @@ from sqlparse import engine
 from sqlparse import tokens
 from sqlparse import filters
 from sqlparse import formatter
-from sqlparse import keywords
+from sqlparse import keywords  # noqa: F401
 
 
 __version__ = '0.5.0.dev0'

--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -14,7 +14,7 @@ from sqlparse import engine
 from sqlparse import tokens
 from sqlparse import filters
 from sqlparse import formatter
-from sqlparse import keywords  # noqa: F401
+from sqlparse import joins  # noqa: F401
 
 
 __version__ = '0.5.0.dev0'

--- a/sqlparse/joins.py
+++ b/sqlparse/joins.py
@@ -1,0 +1,23 @@
+JOIN_TYPES = (
+    'CROSS',
+    'POSITIONAL',
+    [
+        ('', 'NATURAL', 'ASOF'),
+        ('', 'INNER', [('LEFT', 'RIGHT', 'FULL'), ('', 'OUTER')]),
+    ],
+)
+
+
+def types_as_regex(join_types=JOIN_TYPES):
+    if isinstance(join_types, str):
+        return join_types + r'\s+'
+    elif isinstance(join_types, tuple):
+        is_optional = '' in join_types
+        group = '|'.join(
+            types_as_regex(type)
+            for type in join_types
+            if type != ''
+        )
+        return '(?:' + group + ')' + ('?' if is_optional else '')
+    else:
+        return ''.join(types_as_regex(type) for type in join_types)

--- a/sqlparse/joins.py
+++ b/sqlparse/joins.py
@@ -11,7 +11,7 @@ JOIN_TYPES = (
 )
 
 
-def enumerate_types(join_types=[JOIN_TYPES]):
+def enumerate_types(join_types=JOIN_TYPES):
     if isinstance(join_types, str):
         yield (join_types,) if join_types else ()
     elif isinstance(join_types, tuple):

--- a/sqlparse/joins.py
+++ b/sqlparse/joins.py
@@ -1,6 +1,15 @@
 import itertools
 
 
+# this data structure is a kind of grammar for allowed SQL joins. it expands
+# to a sequence of keyword tuples representing valid joins as follows:
+# - tuples expand to a union of the types encoded in each element
+#   - empty string element means the "group" is optional
+# - lists represent product of the types encoded in each element
+# - strings represent a literal option for an element of the type
+#
+# it is mainly modeled after the duckdb join syntax documented here:
+#   https://duckdb.org/docs/sql/query_syntax/from#syntax
 JOIN_TYPES = (
     'STRAIGHT_JOIN',
     [
@@ -17,6 +26,7 @@ JOIN_TYPES = (
 )
 
 
+# generates all valid join types as a sequence of tuples of keywords
 def enumerate_types(join_types=JOIN_TYPES):
     if isinstance(join_types, str):
         yield (join_types,) if join_types else ()
@@ -33,6 +43,8 @@ def enumerate_types(join_types=JOIN_TYPES):
         })
 
 
+# transforms the `JOIN_TYPES` representation into a regex matching any valid'
+# join type, in a format compatible with the lexer's `SQL_REGEX`
 def types_as_regex(join_types=JOIN_TYPES):
     if isinstance(join_types, str):
         return join_types + (r'\b' if 'JOIN' in join_types else r'\s+')

--- a/sqlparse/joins.py
+++ b/sqlparse/joins.py
@@ -1,3 +1,6 @@
+import itertools
+
+
 JOIN_TYPES = (
     'CROSS',
     'POSITIONAL',
@@ -6,6 +9,22 @@ JOIN_TYPES = (
         ('', 'INNER', [('LEFT', 'RIGHT', 'FULL'), ('', 'OUTER')]),
     ],
 )
+
+
+def enumerate_types(join_types=[JOIN_TYPES]):
+    if isinstance(join_types, str):
+        yield (join_types,) if join_types else ()
+    elif isinstance(join_types, tuple):
+        for type in join_types:
+            yield from enumerate_types(type)
+    else:
+        combinations = itertools.product(*[
+            enumerate_types(type) for type in join_types
+        ])
+        yield from sorted({
+            tuple(itertools.chain.from_iterable(combo))
+            for combo in combinations
+        })
 
 
 def types_as_regex(join_types=JOIN_TYPES):

--- a/sqlparse/joins.py
+++ b/sqlparse/joins.py
@@ -2,11 +2,17 @@ import itertools
 
 
 JOIN_TYPES = (
-    'CROSS',
-    'POSITIONAL',
+    'STRAIGHT_JOIN',
     [
-        ('', 'NATURAL', 'ASOF'),
-        ('', 'INNER', [('LEFT', 'RIGHT', 'FULL'), ('', 'OUTER')]),
+        (
+            'CROSS',
+            'POSITIONAL',
+            [
+                ('', 'NATURAL', 'ASOF'),
+                ('', 'INNER', [('LEFT', 'RIGHT', 'FULL'), ('', 'OUTER')]),
+            ],
+        ),
+        'JOIN',
     ],
 )
 
@@ -29,7 +35,7 @@ def enumerate_types(join_types=JOIN_TYPES):
 
 def types_as_regex(join_types=JOIN_TYPES):
     if isinstance(join_types, str):
-        return join_types + r'\s+'
+        return join_types + (r'\b' if 'JOIN' in join_types else r'\s+')
     elif isinstance(join_types, tuple):
         is_optional = '' in join_types
         group = '|'.join(

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -5,37 +5,12 @@
 # This module is part of python-sqlparse and is released under
 # the BSD License: https://opensource.org/licenses/BSD-3-Clause
 
-from sqlparse import tokens
+from sqlparse import tokens, joins
 
 # object() only supports "is" and is useful as a marker
 # use this marker to specify that the given regex in SQL_REGEX
 # shall be processed further through a lookup in the KEYWORDS dictionaries
 PROCESS_AS_KEYWORD = object()
-
-JOIN_TYPES = (
-    'CROSS',
-    'POSITIONAL',
-    [
-        ('', 'NATURAL', 'ASOF'),
-        ('', 'INNER', [('LEFT', 'RIGHT', 'FULL'), ('', 'OUTER')]),
-    ],
-)
-
-
-def join_types_to_regex(join_types):
-    if isinstance(join_types, str):
-        return join_types + r'\s+'
-    elif isinstance(join_types, tuple):
-        is_optional = '' in join_types
-        group = '|'.join(
-            join_types_to_regex(type)
-            for type in join_types
-            if type != ''
-        )
-        return '(?:' + group + ')' + ('?' if is_optional else '')
-    else:
-        return ''.join(join_types_to_regex(type) for type in join_types)
-
 
 SQL_REGEX = [
     (r'(--|# )\+.*?(\r\n|\r|\n|$)', tokens.Comment.Single.Hint),
@@ -92,7 +67,7 @@ SQL_REGEX = [
     # cannot be preceded by word character or a right bracket --
     # otherwise it's probably an array index
     (r'(?<![\w\])])(\[[^\]\[]+\])', tokens.Name),
-    (join_types_to_regex(JOIN_TYPES) + r'JOIN\b', tokens.Keyword),
+    (joins.types_as_regex() + r'JOIN\b', tokens.Keyword),
     (r'END(\s+IF|\s+LOOP|\s+WHILE)?\b', tokens.Keyword),
     (r'NOT\s+NULL\b', tokens.Keyword),
     (r'NULLS\s+(FIRST|LAST)\b', tokens.Keyword),

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -20,15 +20,22 @@ JOIN_TYPES = (
         ('', 'INNER', [('LEFT', 'RIGHT', 'FULL'), ('', 'OUTER')]),
     ],
 )
+
+
 def join_types_to_regex(join_types):
     if isinstance(join_types, str):
         return join_types + r'\s+'
     elif isinstance(join_types, tuple):
         is_optional = '' in join_types
-        group = '|'.join(join_types_to_regex(type) for type in join_types if type != '')
+        group = '|'.join(
+            join_types_to_regex(type)
+            for type in join_types
+            if type != ''
+        )
         return '(?:' + group + ')' + ('?' if is_optional else '')
     else:
         return ''.join(join_types_to_regex(type) for type in join_types)
+
 
 SQL_REGEX = [
     (r'(--|# )\+.*?(\r\n|\r|\n|$)', tokens.Comment.Single.Hint),

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -68,7 +68,7 @@ SQL_REGEX = [
     # cannot be preceded by word character or a right bracket --
     # otherwise it's probably an array index
     (r'(?<![\w\])])(\[[^\]\[]+\])', tokens.Name),
-    (joins.types_as_regex() + r'JOIN\b', tokens.Keyword),
+    (joins.types_as_regex(), tokens.Keyword),
     (r'END(\s+IF|\s+LOOP|\s+WHILE)?\b', tokens.Keyword),
     (r'NOT\s+NULL\b', tokens.Keyword),
     (r'NULLS\s+(FIRST|LAST)\b', tokens.Keyword),

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -686,7 +686,6 @@ KEYWORDS_COMMON = {
     'FROM': tokens.Keyword,
     'INNER': tokens.Keyword,
     'JOIN': tokens.Keyword,
-    'STRAIGHT_JOIN': tokens.Keyword,
     'AND': tokens.Keyword,
     'OR': tokens.Keyword,
     'LIKE': tokens.Keyword,

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -12,6 +12,7 @@ from sqlparse import tokens, joins
 # shall be processed further through a lookup in the KEYWORDS dictionaries
 PROCESS_AS_KEYWORD = object()
 
+
 SQL_REGEX = [
     (r'(--|# )\+.*?(\r\n|\r|\n|$)', tokens.Comment.Single.Hint),
     (r'/\*\+[\s\S]*?\*/', tokens.Comment.Multiline.Hint),

--- a/tests/test_joins.py
+++ b/tests/test_joins.py
@@ -1,0 +1,34 @@
+from sqlparse import joins
+
+
+def test_enumerate_join_types():
+    expected_join_types = {
+        ('JOIN',),
+        ('STRAIGHT_JOIN',),
+        ('CROSS', 'JOIN'),
+        ('POSITIONAL', 'JOIN'),
+        ('NATURAL', 'JOIN'),
+        ('NATURAL', 'INNER', 'JOIN'),
+        ('NATURAL', 'LEFT', 'JOIN'),
+        ('NATURAL', 'LEFT', 'OUTER', 'JOIN'),
+        ('NATURAL', 'RIGHT', 'JOIN'),
+        ('NATURAL', 'RIGHT', 'OUTER', 'JOIN'),
+        ('NATURAL', 'FULL', 'JOIN'),
+        ('NATURAL', 'FULL', 'OUTER', 'JOIN'),
+        ('ASOF', 'JOIN'),
+        ('ASOF', 'INNER', 'JOIN'),
+        ('ASOF', 'LEFT', 'JOIN'),
+        ('ASOF', 'LEFT', 'OUTER', 'JOIN'),
+        ('ASOF', 'RIGHT', 'JOIN'),
+        ('ASOF', 'RIGHT', 'OUTER', 'JOIN'),
+        ('ASOF', 'FULL', 'JOIN'),
+        ('ASOF', 'FULL', 'OUTER', 'JOIN'),
+        ('INNER', 'JOIN'),
+        ('LEFT', 'JOIN'),
+        ('LEFT', 'OUTER', 'JOIN'),
+        ('RIGHT', 'JOIN'),
+        ('RIGHT', 'OUTER', 'JOIN'),
+        ('FULL', 'JOIN'),
+        ('FULL', 'OUTER', 'JOIN'),
+    }
+    assert set(joins.enumerate_types()) == expected_join_types

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -6,7 +6,6 @@ import pytest
 import sqlparse
 from sqlparse import lexer
 from sqlparse import sql, tokens as T
-from sqlparse import keywords
 
 
 def test_tokenize_simple():

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -6,6 +6,7 @@ import pytest
 import sqlparse
 from sqlparse import lexer
 from sqlparse import sql, tokens as T
+from sqlparse import keywords
 
 
 def test_tokenize_simple():
@@ -146,9 +147,8 @@ def test_stream_error():
     'FULL OUTER JOIN',
     'NATURAL JOIN',
     'CROSS JOIN',
-    'STRAIGHT JOIN',
-    'INNER JOIN',
-    'LEFT INNER JOIN'])
+    'STRAIGHT_JOIN',
+    'INNER JOIN'])
 def test_parse_join(expr):
     p = sqlparse.parse('{} foo'.format(expr))[0]
     assert len(p.tokens) == 3


### PR DESCRIPTION
In preparation for tackling [SUP-1229](https://linear.app/hex/issue/SUP-1229/parser-doesnt-pick-up-natural-joins-in-df-sql-cells), this PR redefines the allowed JOIN types for the parser and exports them so they can be reused by `sql-metadata`. I could have fixed SUP-1229 without this change but I figured I might as well fix the other exotic duckdb join styles while I'm at it - `POSITIONAL` and `ASOF` joins, and allowing the combination of inner/outer with natural/asof. I care most about duckdb compatibility here because it's the most liable to create actual execution errors when dataframe references aren't parsed out, but I double checked that these rules seem to be consistent across connectors (only Snowflake comes close to recognizing most of the types). I'm using this diagram from the duckdb docs as the gospel:

![CleanShot 2023-12-04 at 18 30 47@2x](https://github.com/hex-inc/sqlparse/assets/491393/96ce4b32-1452-4103-82f7-defa30e89715)