### PR TITLE
don't consider `result` a keyword

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -466,7 +466,7 @@ KEYWORDS = {
     'RESOURCE': tokens.Keyword,
     'RESTART': tokens.Keyword,
     'RESTRICT': tokens.Keyword,
-    'RESULT': tokens.Keyword,
+    # 'RESULT': tokens.Keyword,
     'RETURN': tokens.Keyword,
     'RETURNED_LENGTH': tokens.Keyword,
     'RETURNED_OCTET_LENGTH': tokens.Keyword,


### PR DESCRIPTION
This is breaking a user query using `result` as a CTE name and preventing a dataframe from being picked up as a dependency ([thread](https://github.com/hex-inc/sqlparse/pull/new/dscott/result-keyword))