### PR TITLE
mark TRUNCATE as a DML keyword

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -574,7 +574,6 @@ KEYWORDS = {
     'TRIGGER_SCHEMA': tokens.Keyword,
     'TRIM': tokens.Keyword,
     'TRUE': tokens.Keyword,
-    'TRUNCATE': tokens.Keyword,
     'TRUSTED': tokens.Keyword,
     'TYPE': tokens.Keyword,
 
@@ -678,6 +677,7 @@ KEYWORDS_COMMON = {
     'UPSERT': tokens.Keyword.DML,
     'REPLACE': tokens.Keyword.DML,
     'MERGE': tokens.Keyword.DML,
+    'TRUNCATE': tokens.Keyword.DML,
     'DROP': tokens.Keyword.DDL,
     'CREATE': tokens.Keyword.DDL,
     'ALTER': tokens.Keyword.DDL,

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -566,3 +566,10 @@ def test_configurable_regex():
         for t in tokens
         if t.ttype not in sqlparse.tokens.Whitespace
     )[4] == (sqlparse.tokens.Keyword, "zorder by")
+
+
+def test_truncate_statement_type():
+    s = "truncate table production"
+    stmts = sqlparse.parse(s)
+    assert len(stmts) == 1
+    assert stmts[0].get_type() == "TRUNCATE"


### PR DESCRIPTION
[SUP-1445](https://linear.app/hex/issue/SUP-1445/trunate-query-statements-are-prunable-during-app-runs): SQL cells using `TRUNCATE` can be considered "select only" because it was marked as a regular old keyword