### PR TITLE
Mark IFF as a keyword

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -34,7 +34,7 @@ SQL_REGEX = [
     # see https://github.com/andialbrecht/sqlparse/pull/64
     # AS and IN are special, it may be followed by a parenthesis, but
     # are never functions, see issue183 and issue507
-    (r"(CASE|IN|VALUES|USING|FROM|AS)\b", tokens.Keyword),
+    (r"(CASE|IN|VALUES|USING|FROM|AS|IFF)\b", tokens.Keyword),
     (r"(PIVOT|PIVOT_WIDER|UNPIVOT)\b", tokens.Keyword),
     (r"(@|##|#)[A-ZÀ-Ü]\w+", tokens.Name),
     # see issue #39
@@ -925,6 +925,7 @@ KEYWORDS_SNOWFLAKE = {
     "TRY_CAST": tokens.Keyword,
     "UNPIVOT": tokens.Keyword,
     "VARIANT": tokens.Name.Builtin,
+    "IFF": tokens.Keyword,
 }
 
 


### PR DESCRIPTION
Doing some work to fix parsing of JOIN statements with IFF clauses in Snowflake, where a query that contains JOIN X ON IFF(condition, table_1.x, table_1.y) = table_2.z will parse table_1.x and table_1.y as tables.

IFF needs to be marked as a keyword, so that the sql-metadata package can set it as the last_keyword for parsing (otherwise the last keyword is set to FROM, which is what causes the issue.


# Thanks for contributing!

Before submitting your pull request please have a look at the
following checklist:

- [ ] ran the tests (`pytest`)
- [ ] all style issues addressed (`flake8`)
- [ ] your changes are covered by tests
- [ ] your changes are documented, if needed

In addition, please take care to provide a proper description
on what your change does, fixes or achieves when submitting the 
pull request.