### PR TITLE
Fix O(n²) performance in ReindentFilter for large queries

### DIFF
--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -26,25 +26,49 @@ class ReindentFilter:
         self._last_stmt = None
         self._last_func = None
 
-    def _flatten_up_to_token(self, token):
-        """Yields all tokens up to token but excluding current."""
-        if token.is_group:
-            token = next(token.flatten())
-
-        for t in self._curr_stmt.flatten():
-            if t == token:
+    def _reverse_leaves_before(self, target_leaf):
+        """Yield leaf token values in reverse order before target_leaf."""
+        current = target_leaf
+        while current is not self._curr_stmt and current.parent is not None:
+            parent = current.parent
+            try:
+                idx = parent.tokens.index(current)
+            except ValueError:
                 break
-            yield t
+            for i in range(idx - 1, -1, -1):
+                sibling = parent.tokens[i]
+                if sibling.is_group:
+                    yield from self._reverse_flatten(sibling)
+                else:
+                    yield sibling.value
+            current = parent
+
+    def _reverse_flatten(self, token_list):
+        """Yield all leaf token values in a TokenList in reverse order."""
+        for i in range(len(token_list.tokens) - 1, -1, -1):
+            child = token_list.tokens[i]
+            if child.is_group:
+                yield from self._reverse_flatten(child)
+            else:
+                yield child.value
 
     @property
     def leading_ws(self):
         return self.offset + self.indent * self.width
 
     def _get_offset(self, token):
-        raw = ''.join(map(str, self._flatten_up_to_token(token)))
-        line = (raw or '\n').splitlines()[-1]
-        # Now take current offset into account and return relative offset.
-        return len(line) - len(self.char * self.leading_ws)
+        if token.is_group:
+            token = next(token.flatten())
+
+        column = 0
+        for value in self._reverse_leaves_before(token):
+            newline_pos = value.rfind('\n')
+            if newline_pos != -1:
+                column += len(value) - newline_pos - 1
+                break
+            column += len(value)
+
+        return column - len(self.char * self.leading_ws)
 
     def nl(self, offset=0):
         return sql.Token(
@@ -136,37 +160,57 @@ class ReindentFilter:
             num_offset = 1 if self.char == '\t' else self._get_offset(first)
 
         if not tlist.within(sql.Function) and not tlist.within(sql.Values):
+            # Build index mapping for O(1) lookups instead of O(n)
+            # token_index calls
+            token_to_idx = {id(t): i
+                            for i, t in enumerate(tlist.tokens)}
             with offset(self, num_offset):
                 position = 0
+                shift = 0
                 for token in identifiers:
                     # Add 1 for the "," separator
                     position += len(token.value) + 1
                     if position > (self.wrap_after - self.offset):
                         adjust = 0
+                        tidx = token_to_idx[id(token)] + shift
                         if self.comma_first:
                             adjust = -2
-                            _, comma = tlist.token_prev(
-                                tlist.token_index(token))
+                            pidx, comma = tlist.token_prev(tidx)
                             if comma is None:
                                 continue
-                            token = comma
-                        tlist.insert_before(token, self.nl(offset=adjust))
-                        if self.comma_first:
+                            tlist.insert_before(
+                                pidx, self.nl(offset=adjust))
+                            shift += 1
+                            # comma is now at pidx + 1
                             _, ws = tlist.token_next(
-                                tlist.token_index(token), skip_ws=False)
+                                pidx + 1, skip_ws=False)
                             if (ws is not None
-                                    and ws.ttype is not T.Text.Whitespace):
+                                    and ws.ttype is not
+                                    T.Text.Whitespace):
                                 tlist.insert_after(
-                                    token, sql.Token(T.Whitespace, ' '))
+                                    pidx + 1,
+                                    sql.Token(T.Whitespace, ' '))
+                                shift += 1
+                        else:
+                            tlist.insert_before(
+                                tidx, self.nl(offset=adjust))
+                            shift += 1
                         position = 0
         else:
             # ensure whitespace
-            for token in tlist:
-                _, next_ws = tlist.token_next(
-                    tlist.token_index(token), skip_ws=False)
-                if token.value == ',' and not next_ws.is_whitespace:
-                    tlist.insert_after(
-                        token, sql.Token(T.Whitespace, ' '))
+            token_to_idx = {id(t): i
+                            for i, t in enumerate(tlist.tokens)}
+            ws_shift = 0
+            for token in list(tlist.tokens):
+                if token.value == ',':
+                    adj_i = token_to_idx[id(token)] + ws_shift
+                    _, next_ws = tlist.token_next(
+                        adj_i, skip_ws=False)
+                    if (next_ws is not None
+                            and not next_ws.is_whitespace):
+                        tlist.insert_after(
+                            adj_i, sql.Token(T.Whitespace, ' '))
+                        ws_shift += 1
 
             end_at = self.offset + sum(len(i.value) + 1 for i in identifiers)
             adjusted_offset = 0
@@ -175,17 +219,25 @@ class ReindentFilter:
                     and self._last_func):
                 adjusted_offset = -len(self._last_func.value) - 1
 
+            # Rebuild index mapping after whitespace insertions
+            token_to_idx = {id(t): i
+                            for i, t in enumerate(tlist.tokens)}
             with offset(self, adjusted_offset), indent(self):
+                shift = 0
                 if adjusted_offset < 0:
-                    tlist.insert_before(identifiers[0], self.nl())
+                    idx0 = token_to_idx[id(identifiers[0])] + shift
+                    tlist.insert_before(idx0, self.nl())
+                    shift += 1
                 position = 0
                 for token in identifiers:
                     # Add 1 for the "," separator
                     position += len(token.value) + 1
                     if (self.wrap_after > 0
                             and position > (self.wrap_after - self.offset)):
-                        adjust = 0
-                        tlist.insert_before(token, self.nl(offset=adjust))
+                        tidx = token_to_idx[id(token)] + shift
+                        tlist.insert_before(
+                            tidx, self.nl(offset=0))
+                        shift += 1
                         position = 0
         self._process_default(tlist)
 

--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -26,15 +26,18 @@ class ReindentFilter:
         self._last_stmt = None
         self._last_func = None
 
-    def _reverse_leaves_before(self, target_leaf):
+    def _reverse_leaves_before(self, target_leaf, _parent_idx=None):
         """Yield leaf token values in reverse order before target_leaf."""
         current = target_leaf
         while current is not self._curr_stmt and current.parent is not None:
             parent = current.parent
-            try:
-                idx = parent.tokens.index(current)
-            except ValueError:
-                break
+            if _parent_idx is not None and parent is _parent_idx[0]:
+                idx = _parent_idx[1]
+            else:
+                try:
+                    idx = parent.tokens.index(current)
+                except ValueError:
+                    break
             for i in range(idx - 1, -1, -1):
                 sibling = parent.tokens[i]
                 if sibling.is_group:
@@ -56,12 +59,12 @@ class ReindentFilter:
     def leading_ws(self):
         return self.offset + self.indent * self.width
 
-    def _get_offset(self, token):
+    def _get_offset(self, token, _parent_idx=None):
         if token.is_group:
             token = next(token.flatten())
 
         column = 0
-        for value in self._reverse_leaves_before(token):
+        for value in self._reverse_leaves_before(token, _parent_idx):
             newline_pos = value.rfind('\n')
             if newline_pos != -1:
                 column += len(value) - newline_pos - 1
@@ -268,17 +271,21 @@ class ReindentFilter:
         tlist.insert_before(0, self.nl())
         tidx, token = tlist.token_next_by(i=sql.Parenthesis)
         first_token = token
+
+        # Hoist loop-invariant offset for comma_first mode
+        if self.comma_first and first_token:
+            cf_offset = self._get_offset(first_token) - 2
+
         while token:
             ptidx, ptoken = tlist.token_next_by(m=(T.Punctuation, ','),
                                                 idx=tidx)
             if ptoken:
                 if self.comma_first:
-                    adjust = -2
-                    offset = self._get_offset(first_token) + adjust
-                    tlist.insert_before(ptoken, self.nl(offset))
+                    tlist.insert_before(ptidx, self.nl(cf_offset))
                 else:
-                    tlist.insert_after(ptoken,
-                                       self.nl(self._get_offset(token)))
+                    nl_offset = self._get_offset(
+                        token, _parent_idx=(tlist, tidx))
+                    tlist.insert_after(ptidx, self.nl(nl_offset))
             tidx, token = tlist.token_next_by(i=sql.Parenthesis, idx=tidx)
 
     def _process_default(self, tlist, stmts=True):

--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -26,13 +26,14 @@ class ReindentFilter:
         self._last_stmt = None
         self._last_func = None
 
-    def _reverse_leaves_before(self, target_leaf, _parent_idx=None):
+    def _reverse_leaves_before(self, target_leaf, known_parent_and_idx=None):
         """Yield leaf token values in reverse order before target_leaf."""
         current = target_leaf
         while current is not self._curr_stmt and current.parent is not None:
             parent = current.parent
-            if _parent_idx is not None and parent is _parent_idx[0]:
-                idx = _parent_idx[1]
+            if known_parent_and_idx is not None \
+                    and parent is known_parent_and_idx[0]:
+                idx = known_parent_and_idx[1]
             else:
                 try:
                     idx = parent.tokens.index(current)
@@ -59,12 +60,12 @@ class ReindentFilter:
     def leading_ws(self):
         return self.offset + self.indent * self.width
 
-    def _get_offset(self, token, _parent_idx=None):
+    def _get_offset(self, token, known_parent_and_idx=None):
         if token.is_group:
             token = next(token.flatten())
 
         column = 0
-        for value in self._reverse_leaves_before(token, _parent_idx):
+        for value in self._reverse_leaves_before(token, known_parent_and_idx):
             newline_pos = value.rfind('\n')
             if newline_pos != -1:
                 column += len(value) - newline_pos - 1
@@ -272,7 +273,6 @@ class ReindentFilter:
         tidx, token = tlist.token_next_by(i=sql.Parenthesis)
         first_token = token
 
-        # Hoist loop-invariant offset for comma_first mode
         if self.comma_first and first_token:
             cf_offset = self._get_offset(first_token) - 2
 
@@ -284,7 +284,7 @@ class ReindentFilter:
                     tlist.insert_before(ptidx, self.nl(cf_offset))
                 else:
                     nl_offset = self._get_offset(
-                        token, _parent_idx=(tlist, tidx))
+                        token, known_parent_and_idx=(tlist, tidx))
                     tlist.insert_after(ptidx, self.nl(nl_offset))
             tidx, token = tlist.token_next_by(i=sql.Parenthesis, idx=tidx)
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,145 @@
+"""Benchmark tests for sqlparse.format(reindent=True) on large SQL queries.
+
+Run with:
+    uv run --with pytest --with pytest-benchmark pytest tests/test_benchmarks.py -v
+"""
+
+import pytest
+import sqlparse
+
+pytest.importorskip("pytest_benchmark")
+
+
+# ---------------------------------------------------------------------------
+# Query generators — deterministic, no randomness
+# ---------------------------------------------------------------------------
+
+def _wide_select_sql(n_cols=5000):
+    cols = ', '.join(f'col_{i}' for i in range(n_cols))
+    return f'SELECT {cols} FROM t'
+
+
+def _large_in_list_sql(n=100000):
+    values = ', '.join(str(i) for i in range(n))
+    return f'SELECT * FROM t WHERE id IN ({values})'
+
+
+def _large_insert_sql(n_rows=25000):
+    rows = ', '.join(f'({i}, {i+1})' for i in range(n_rows))
+    return f'INSERT INTO t VALUES {rows}'
+
+
+def _deep_subqueries_sql(depth=12):
+    q = 'SELECT * FROM t'
+    for i in range(depth):
+        q = f'SELECT * FROM ({q}) s{i}'
+    return q
+
+
+def _many_joins_sql(n=500):
+    joins = ' '.join(
+        f'JOIN t{i} ON t{i}.id = t{i-1}.id' for i in range(1, n + 1))
+    return f'SELECT * FROM t0 {joins}'
+
+
+def _complex_where_sql(depth=8, breadth=3):
+    def _build(d, idx=0):
+        if d == 0:
+            return f'col_{idx} = {idx}'
+        conn = 'AND' if d % 2 == 0 else 'OR'
+        parts = []
+        for i in range(breadth):
+            parts.append(_build(d - 1, idx * breadth + i))
+        return '(' + f' {conn} '.join(parts) + ')'
+    return f'SELECT * FROM t WHERE {_build(depth)}'
+
+
+def _mixed_batch_sql(n=50):
+    stmts = []
+    for i in range(n):
+        if i % 4 == 0:
+            cols = ', '.join(f'col_{j} INT' for j in range(20))
+            stmts.append(f'CREATE TABLE t_{i} ({cols})')
+        elif i % 4 == 1:
+            rows = ', '.join(f'({j}, {j+1})' for j in range(100))
+            stmts.append(f'INSERT INTO t_{i} VALUES {rows}')
+        elif i % 4 == 2:
+            cols = ', '.join(f't.col_{j}' for j in range(20))
+            stmts.append(f'SELECT {cols} FROM t_{i} t WHERE t.col_0 > 0')
+        else:
+            stmts.append(
+                f'UPDATE t_{i} SET col_0 = col_0 + 1 WHERE col_1 > 0')
+    return '; '.join(stmts)
+
+
+def _heavy_formatting_sql():
+    cases = ', '.join(
+        f'CASE WHEN col_{i} > 0 THEN col_{i} ELSE 0 END AS c_{i}'
+        for i in range(200))
+    return (
+        f'WITH cte AS (SELECT {cases} FROM t) '
+        f'SELECT * FROM cte WHERE c_0 > 0 ORDER BY c_1'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reindent benchmarks (one per PR table row)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.benchmark(group="reindent")
+def test_wide_select(benchmark):
+    sql = _wide_select_sql()
+    benchmark(sqlparse.format, sql, reindent=True)
+
+
+@pytest.mark.benchmark(group="reindent")
+def test_large_in_list(benchmark):
+    sql = _large_in_list_sql()
+    benchmark(sqlparse.format, sql, reindent=True)
+
+
+@pytest.mark.benchmark(group="reindent")
+def test_large_insert(benchmark):
+    sql = _large_insert_sql()
+    benchmark(sqlparse.format, sql, reindent=True)
+
+
+@pytest.mark.benchmark(group="reindent")
+def test_deep_subqueries(benchmark):
+    sql = _deep_subqueries_sql()
+    benchmark(sqlparse.format, sql, reindent=True)
+
+
+@pytest.mark.benchmark(group="reindent")
+def test_many_joins(benchmark):
+    sql = _many_joins_sql()
+    benchmark(sqlparse.format, sql, reindent=True)
+
+
+@pytest.mark.benchmark(group="reindent")
+def test_complex_where(benchmark):
+    sql = _complex_where_sql()
+    benchmark(sqlparse.format, sql, reindent=True)
+
+
+@pytest.mark.benchmark(group="reindent")
+def test_mixed_batch(benchmark):
+    sql = _mixed_batch_sql()
+    benchmark(sqlparse.format, sql, reindent=True)
+
+
+@pytest.mark.benchmark(group="reindent")
+def test_heavy_formatting(benchmark):
+    sql = _heavy_formatting_sql()
+    benchmark(sqlparse.format, sql, reindent=True)
+
+
+# ---------------------------------------------------------------------------
+# INSERT scaling benchmarks (_process_values)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.benchmark(group="insert-scaling")
+@pytest.mark.parametrize("n_rows", [5000, 10000, 25000], ids=["5k", "10k", "25k"])
+def test_insert_scaling(benchmark, n_rows):
+    sql = _large_insert_sql(n_rows)
+    benchmark(sqlparse.format, sql, reindent=True)


### PR DESCRIPTION
After reviewing https://github.com/hex-inc/sqlparse/pull/16, I set claude loose on the repo and asked it to stress test other forms of large queries to look for similar cases. And it found 3.  The issues and fixes are described below. I also had it added `pytest-benchmark` benchmarks for a bunch of cases and report the speedups.

---

## Summary

Fix O(n²) performance bottlenecks in `ReindentFilter` that cause `sqlparse.format(..., reindent=True)` to hang on large SQL queries. After these fixes, the same queries format in seconds.

This is a companion to #16 which fixes parse-time O(n²) in `group_tokens`. This branch fixes the remaining format-time O(n²) in the reindent filter.

## Changes

### Fix 1: Replace `_get_offset` with backward tree walk

- **Old**: `_flatten_up_to_token` concatenated all tokens from the start of the statement, then took `splitlines()[-1]` to get the current line — O(statement_length) per call
- **New**: Walk backward from the target token through the tree until a newline is found — O(line_length) per call
- Added `_reverse_leaves_before` and `_reverse_flatten` for the backward walk
- Removed the now-unused `_flatten_up_to_token` method

### Fix 2: Eliminate `token_index` calls in `_process_identifierlist`

- **Old**: `insert_before(token, ...)` called `token_index(token)` → `list.index(token)` = O(n) linear scan per insertion
- **New**: Pre-compute `{id(token): index}` mapping once, pass integer indices directly to `insert_before`/`insert_after`, and track cumulative `shift` from insertions

### Fix 3: Eliminate O(n²) in `_process_values` for large INSERT statements

- **Old**: Same two O(n²) patterns as above in the VALUES processing loop
- **New**: Pass integer indices from `token_next_by` directly. Added `_parent_idx` hint parameter so the backward walk skips the O(n) `index()` call on the hot parent. Hoisted loop-invariant offset in `comma_first` mode.

## Benchmark Results

Reproducible benchmark tests are included in the first commit (`tests/test_benchmarks.py`). Run with:

```bash
uv run --with pytest --with pytest-benchmark pytest tests/test_benchmarks.py -v
```

### Reindent benchmarks

| Benchmark | Example SQL | Before | After | Speedup |
|---|---|---|---|---|
| wide_select | `SELECT col_0, col_1, ... col_4999 FROM t` | 0.66s | 0.16s | **4.1x** |
| large_in_list | `SELECT * FROM t WHERE id IN (0, 1, ... 99999)` | DNF (>120s) | 6.39s | **FIXED** |
| large_insert | `INSERT INTO t VALUES (0, 1), (1, 2), ... (24999, 25000)` | DNF (>120s) | 2.56s | **FIXED** |
| deep_subqueries | `SELECT * FROM (SELECT * FROM (... FROM t ...) s0) s11` | 0.00s | 0.00s | — |
| many_joins | `SELECT * FROM t0 JOIN t1 ON ... JOIN t2 ON ... (×500)` | 0.07s | 0.07s | — |
| complex_where | `SELECT * FROM t WHERE ((col_0 = 0 AND ...) OR ...) (depth=8, breadth=3)` | 16.56s | 0.60s | **27.6x** |
| mixed_batch | `CREATE TABLE ...; INSERT INTO ...; SELECT ...; UPDATE ... (×50)` | 0.20s | 0.13s | 1.5x |
| heavy_formatting | `WITH cte AS (SELECT CASE WHEN col_0 > 0 ... (×200)) SELECT * FROM cte` | 0.20s | 0.05s | 4.0x |

### INSERT scaling (Fix 3)

| Benchmark | Example SQL | Before | After | Speedup |
|---|---|---|---|---|
| insert 5k rows | `INSERT INTO t VALUES (0, 1), ... (4999, 5000)` | 13.26s | 0.37s | **35.8x** |
| insert 10k rows | `INSERT INTO t VALUES (0, 1), ... (9999, 10000)` | DNF (>120s) | 0.86s | **FIXED** |
| insert 25k rows | `INSERT INTO t VALUES (0, 1), ... (24999, 25000)` | DNF (>120s) | 2.47s | **FIXED** |

## Testing

- All 467 existing tests pass
- 11 pytest-benchmark tests included for reproducible performance measurement