### PR TITLE
ci: Fix pre-existing flake8 lint errors

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -77,7 +77,8 @@ SQL_REGEX = [
     (r"HANDLER\s+FOR\b", tokens.Keyword),
     (r"GO(\s\d+)\b", tokens.Keyword),
     (
-        r"(LATERAL\s+VIEW\s+)" r"(EXPLODE|INLINE|PARSE_URL_TUPLE|POSEXPLODE|STACK)\b",
+        r"(LATERAL\s+VIEW\s+)"
+        r"(EXPLODE|INLINE|PARSE_URL_TUPLE|POSEXPLODE|STACK)\b",
         tokens.Keyword,
     ),
     (r"(AT|WITH')\s+TIME\s+ZONE\s+'[^']+'", tokens.Keyword.TZCast),

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -81,7 +81,9 @@ class Lexer:
     def set_SQL_REGEX(self, SQL_REGEX):
         """Set the list of regex that will parse the SQL."""
         FLAGS = re.IGNORECASE | re.UNICODE
-        self._SQL_REGEX = [(re.compile(rx, FLAGS).match, tt) for rx, tt in SQL_REGEX]
+        self._SQL_REGEX = [
+            (re.compile(rx, FLAGS).match, tt) for rx, tt in SQL_REGEX
+        ]
 
     def add_keywords(self, keywords):
         """Add keyword dictionaries. Keywords are looked up in the same order
@@ -129,7 +131,8 @@ class Lexer:
                     text = text.decode("unicode-escape")
         else:
             raise TypeError(
-                "Expected text or file-like object, got {!r}".format(type(text))
+                "Expected text or file-like object, got {!r}".format(
+                    type(text))
             )
 
         iterable = enumerate(text)

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -82,7 +82,8 @@ class Token:
         value = self._get_repr_value()
 
         q = '"' if value.startswith("'") and value.endswith("'") else "'"
-        return "<{cls} {q}{value}{q} at 0x{id:2X}>".format(id=id(self), **locals())
+        return "<{cls} {q}{value}{q} at 0x{id:2X}>".format(
+            id=id(self), **locals())
 
     def _get_repr_name(self):
         return str(self.ttype).split(".")[-1]
@@ -331,7 +332,8 @@ class TokenList(Token):
         start = start if isinstance(start, int) else self.token_index(start)
         return start + self.tokens[start:].index(token)
 
-    def group_tokens(self, grp_cls, start, end, include_end=True, extend=False):
+    def group_tokens(self, grp_cls, start, end,
+                     include_end=True, extend=False):
         """Replace tokens by an instance of *grp_cls*."""
         start_idx = start
         start = self.tokens[start_idx]
@@ -343,11 +345,11 @@ class TokenList(Token):
         #     tokens = tokens[:-1]
 
         if extend and isinstance(start, grp_cls):
-            subtokens = self.tokens[start_idx + 1 : end_idx]
+            subtokens = self.tokens[start_idx + 1:end_idx]
 
             grp = start
             grp.tokens.extend(subtokens)
-            del self.tokens[start_idx + 1 : end_idx]
+            del self.tokens[start_idx + 1:end_idx]
             grp.value = str(start)
         else:
             subtokens = self.tokens[start_idx:end_idx]
@@ -408,7 +410,8 @@ class TokenList(Token):
         _, prev_ = self.token_prev(dot_idx)
         return remove_quotes(prev_.value) if prev_ is not None else None
 
-    def _get_first_name(self, idx=None, reverse=False, keywords=False, real_name=False):
+    def _get_first_name(self, idx=None, reverse=False,
+                        keywords=False, real_name=False):
         """Returns the name of the first token with a name"""
 
         tokens = self.tokens[idx:] if idx else self.tokens
@@ -682,7 +685,8 @@ class Function(NameAliasMixin, TokenList):
         for token in parenthesis.tokens:
             if isinstance(token, IdentifierList):
                 return token.get_identifiers()
-            elif imt(token, i=(Function, Identifier, TypedLiteral), t=T.Literal):
+            elif imt(token, i=(Function, Identifier, TypedLiteral),
+                     t=T.Literal):
                 result.append(token)
         return result
 


### PR DESCRIPTION
## Summary
- Fix 7x E501 (line too long) violations in `keywords.py`, `lexer.py`, and `sql.py`
- Fix 2x E203 (whitespace before ':') violations in `sql.py`
- These errors predate this branch — they were introduced in earlier hex fork changes

## Test plan
- [x] `hatch run flake8` passes cleanly
- [x] All 470 tests pass (`hatch run unittest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)